### PR TITLE
feat(github-actions): add OCI publish, security scan, and build workflows

### DIFF
--- a/.github/workflows/terraform-build.yml
+++ b/.github/workflows/terraform-build.yml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+---
+name: Terraform / Build
+
+on:
+  pull_request:
+    paths:
+      - '**/*.tf'
+  workflow_dispatch:  # Allow manual triggering
+
+permissions:
+  contents: read
+
+jobs:
+  validation:
+    name: Terraform Validation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Terraform
+        id: setup-terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+
+      - name: Terraform Format
+        run: terraform fmt -check
+
+      - name: Terraform Init
+        run: terraform init
+
+      - name: Terraform Validate
+        run: terraform validate -no-color

--- a/.github/workflows/terraform-deps.yaml
+++ b/.github/workflows/terraform-deps.yaml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+---
+name: Terraform / Dependencies
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the main branch
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:  # Allow manual triggering
+
+permissions:
+  contents: write  # required for dependency graph submission
+
+jobs:
+  dependencies:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run Trivy in GitHub SBOM mode and submit results to Dependency Graph
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
+        with:
+          scan-type: 'fs'
+          format: 'github'
+          output: 'dependency-results.sbom.json'
+          github-pat: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload trivy report as a Github artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: trivy-sbom-report
+          path: '${{ github.workspace }}/dependency-results.sbom.json'
+          retention-days: 20 # 90 is the default

--- a/.github/workflows/terraform-oci.yaml
+++ b/.github/workflows/terraform-oci.yaml
@@ -1,0 +1,166 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+---
+name: Terraform / OCI
+
+on:
+  push:
+    tags:
+      - v*
+  workflow_dispatch:  # Allow manual triggering
+
+permissions:
+  contents: read
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  publish-oci:
+    permissions:
+      attestations: write # need for Artifact Attestations
+      contents: write     # to push chart release and create a release (helm/chart-releaser-action)
+      id-token: write     # needed for keyless signing
+      packages: write     # needed for ghcr access
+
+    runs-on: ubuntu-latest
+
+    outputs:
+      digest: ${{ steps.get-digest.outputs.digest }}
+      image: ${{ env.REGISTRY }}/${{ github.repository_owner }}/modules/${{ steps.release-details.outputs.release_name }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Extract repository name
+        run: |
+          REPO_NAME=$(basename "${GITHUB_REPOSITORY}")
+          echo "Repository name: $REPO_NAME"
+          echo "REPO_NAME=$REPO_NAME" >> "$GITHUB_ENV"
+
+      - name: Extract Terraform module name and version
+        id: release-details
+        env:
+          MODULE_NAME: ${{ env.REPO_NAME }}
+          MODULE_VERSION: ${{ github.ref_name }}
+        run: |
+          echo release_name=$MODULE_NAME >> "$GITHUB_OUTPUT"
+          echo release_version=$MODULE_VERSION >> "$GITHUB_OUTPUT"
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Oras
+        uses: oras-project/setup-oras@5c0b487ce3fe0ce3ab0d034e63669e426e294e2d # v1.2.2
+
+      - name: Push Terraform module to GHCR
+        env:
+          MODULE_IMAGE: ${{ env.REGISTRY }}/${{ github.repository_owner }}/modules/${{ steps.release-details.outputs.release_name }}
+          MODULE_VERSION: ${{ steps.release-details.outputs.release_version }}
+          MODULE_NAME: ${{ steps.release-details.outputs.release_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          oras version
+          oras push "${MODULE_IMAGE}:${MODULE_VERSION}" \
+            --artifact-type application/vnd.terraform.module \
+            --annotation "org.opencontainers.image.title=Terraform ACK Module" \
+            --annotation "org.opencontainers.image.description=Provision AWS IAM resources for ACK with Terraform" \
+            --annotation "org.opencontainers.image.authors=Nicolas Lamirault <nicolas.lamirault@gmail.com>" \
+            --annotation "org.opencontainers.image.version=${MODULE_VERSION}" \
+            --annotation "org.opencontainers.image.ref.name=${MODULE_NAME}" \
+            --annotation "org.opencontainers.image.source=https://github.com/${REPO}" \
+            --annotation "org.opencontainers.image.documentation=https://github.com/${REPO}" \
+            --annotation "org.opencontainers.image.issue-tracker=https://github.com/${REPO}/issues" \
+            --annotation "org.opencontainers.image.licenses=Apache-2.0" \
+            modules/
+
+      - name: Setup Crane
+        uses: imjasonh/setup-crane@31b88efe9de28ae0ffa220711af4b60be9435f6e # v0.4
+
+      - name: Get pushed module digest
+        id: get-digest
+        env:
+          MODULE_IMAGE: ${{ env.REGISTRY }}/${{ github.repository_owner }}/modules/${{ steps.release-details.outputs.release_name }}
+          MODULE_VERSION: ${{ steps.release-details.outputs.release_version }}
+        run: |
+          digest=$(crane digest "${MODULE_IMAGE}:${MODULE_VERSION}")
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+          echo "$digest"
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+
+      - name: Sign with Cosign
+        env:
+          MODULE_IMAGE: ${{ env.REGISTRY }}/${{ github.repository_owner }}/modules/${{ steps.release-details.outputs.release_name }}
+          DIGEST: ${{ steps.get-digest.outputs.digest }}
+          REPO: ${{ github.repository }}
+        run: |
+          artifact_digest_uri="${MODULE_IMAGE}@${DIGEST}"
+          cosign sign --yes "${artifact_digest_uri}"
+          cosign verify "${artifact_digest_uri}" \
+              --certificate-identity-regexp "https://github.com/${REPO}/*" \
+              --certificate-oidc-issuer https://token.actions.githubusercontent.com
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@a930d0ac434e3182448fe678398ba5713717112a # v0.21.0
+        with:
+          path: ./modules/
+          artifact-name: sbom-${{ steps.release-details.outputs.release_name }}
+          output-file: ./sbom-${{ steps.release-details.outputs.release_name }}.spdx.json
+
+      - name: Attest
+        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ github.repository_owner }}/modules/${{ steps.release-details.outputs.release_name }}
+          subject-digest: ${{ steps.get-digest.outputs.digest }}
+          push-to-registry: true
+
+  terraform-provenance:
+    needs:
+      - publish-oci
+    permissions:
+      actions: read     # To read the workflow path.
+      id-token: write   # To sign the provenance.
+      packages: write   # To upload assets to release.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
+    with:
+      digest: "${{ needs.publish-oci.outputs.digest }}"
+      image: "${{ needs.publish-oci.outputs.image }}"
+      registry-username: ${{ github.actor }}
+    secrets:
+      registry-password: ${{ secrets.GITHUB_TOKEN }}
+
+  verification-with-cosign:
+    needs:
+      - publish-oci
+      - terraform-provenance
+    runs-on: ubuntu-latest
+    permissions: read-all
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+
+      - name: Verify image
+        env:
+          IMAGE: "${{ needs.publish-oci.outputs.image }}"
+          DIGEST: ${{ needs.publish-oci.outputs.digest }}
+        run: |
+          cosign verify-attestation \
+              --type slsaprovenance \
+              --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+              --certificate-identity-regexp '^https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@refs/tags/v[0-9]+.[0-9]+.[0-9]+$' \
+              "$IMAGE@$DIGEST"

--- a/.github/workflows/terraform-security.yml
+++ b/.github/workflows/terraform-security.yml
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+---
+name: Terraform / Security
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the main branch
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:  # Allow manual triggering
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run Trivy
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
+        with:
+          scan-type: 'config'
+          hide-progress: false
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          exit-code: '1'
+          severity: 'CRITICAL,HIGH'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@0499de31b99561a6d14a36a5f662c2a54f91beee # v4.31.2
+        if: always()
+        with:
+          sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/terraform-security.yml
+++ b/.github/workflows/terraform-security.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run Trivy
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
         with:
           scan-type: 'config'
           hide-progress: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,44 @@
 # Terraform module for AWS ACK
 
-![Tfsec](https://github.com/nlamirault/terraform-aws-teleport/workflows/Tfsec/badge.svg)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/xxxxx/badge)](https://www.bestpractices.dev/en/projects/xxxxx)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/nlamirault/terraform-aws-ack/badge)](https://securityscorecards.dev/viewer/?uri=github.com/nlamirault/terraform-aws-ac)
+[![SLSA 3](https://slsa.dev/images/gh-badge-level3.svg)](https://slsa.dev)
+
+## SLSA
+
+All _artifacts_ provided by this repository meet [SLSA L3](https://slsa.dev/spec/v1.0/levels#build-l3)
+
+### Verify SLSA provenance using the Github CLI
+
+```shell
+$ gh attestation verify oci://ghcr.io/nlamirault/modules/terraform-aws-ack:v2.0.0 --repo nlamirault/terraform-aws-ack
+
+```
+
+### Verify SLSA provenance using Cosign
+
+```shell
+$ cosign verify-attestation \
+  --type slsaprovenance \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp '^https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@refs/tags/v[0-9]+.[0-9]+.[0-9]+$' \
+  ghcr.io/nlamirault/modules/terraform-aws-ack:v2.0.0@sha256:
+
+
+...
+```
+
+## OCI
+
+You could discover all the referrers of manifest with annotations, displayed in a tree view:
+
+```shell
+$ oras discover --format tree ghcr.io/nlamirault/modules/terraform-aws-ack:v2.0.0
+
+```
+
+
 
 ## Documentation
 
@@ -46,3 +84,11 @@
 
 No outputs.
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+## Contributing
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md)
+
+## License
+
+[Apache 2.0 License](./LICENSE)


### PR DESCRIPTION
Add GitHub Actions workflows to automate Terraform module OCI publishing to GHCR with SLSA Level 3 provenance and cosign keyless signing, Trivy security scanning with SARIF upload to GitHub Security tab, dependency SBOM generation submitted to the GitHub dependency graph, and Terraform fmt/init/validate checks triggered on PRs.