### PR TITLE
ci(github): fix changelog sections and renovate semantic commits

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -36,6 +36,16 @@
       "type": "docs",
       "section": "📚 Documentation",
       "hidden": false
+    },
+    {
+      "type": "refactor",
+      "section": "🚧 Changes",
+      "hidden": false
+    },
+    {
+      "type": "ci",
+      "section": "🚨 Maintenance",
+      "hidden": false
     }
   ]
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,7 @@
 {
   "extends": [
-    "config:base",
+    "config:recommended",
+    ":semanticCommits",
     ":gitSignOff"
   ],
   "enabled": true,


### PR DESCRIPTION
## Summary

- Switch Renovate from `config:base` to `config:recommended` and add `:semanticCommits` so dependency update commits follow conventional format (`chore(deps): ...`) and appear in changelog
- Add `refactor` and `ci` types to release-please `changelog-sections` so commits using those types are no longer silently dropped from release notes