### PR TITLE
fix(github): fix oras push and sbom path for root-level module

### DIFF
--- a/.github/workflows/terraform-oci.yaml
+++ b/.github/workflows/terraform-oci.yaml
@@ -78,7 +78,7 @@ jobs:
             --annotation "org.opencontainers.image.documentation=https://github.com/${REPO}" \
             --annotation "org.opencontainers.image.issue-tracker=https://github.com/${REPO}/issues" \
             --annotation "org.opencontainers.image.licenses=Apache-2.0" \
-            modules/
+            .
 
       - name: Setup Crane
         uses: imjasonh/setup-crane@31b88efe9de28ae0ffa220711af4b60be9435f6e # v0.4
@@ -111,7 +111,7 @@ jobs:
       - name: Generate SBOM
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
-          path: ./modules/
+          path: .
           artifact-name: sbom-${{ steps.release-details.outputs.release_name }}
           output-file: ./sbom-${{ steps.release-details.outputs.release_name }}.spdx.json
 


### PR DESCRIPTION
## Summary

- Fix `oras push` target path from `modules/` to `.` — this repo stores Terraform files at root, not in a subdirectory
- Fix SBOM scan path from `./modules/` to `.` for the same reason
- Both changes unblock the OCI publish workflow which failed with `no such file or directory`