### PR TITLE
fix(github): revert setup-oras to v1.2.4 to fix OCI workflow startup_failure

### DIFF
--- a/.github/workflows/terraform-oci.yaml
+++ b/.github/workflows/terraform-oci.yaml
@@ -58,7 +58,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Oras
-        uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
+        uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v1.2.4
 
       - name: Push Terraform module to GHCR
         env:


### PR DESCRIPTION
## Summary

- `oras-project/setup-oras@v2.0.0` (merged via #162) uses `runs: using: node24` in its `action.yml`
- GitHub Actions does not yet support `node24` as a valid JavaScript action runtime (only `node16`/`node20`)
- This caused the `Terraform / OCI` workflow to fail with `startup_failure` — the workflow couldn't even be queued, resulting in zero jobs running
- Fix: pin back to `v1.2.4` (`22ce207`) which uses `node20`

## Root cause

```
# setup-oras v2.0.0 action.yml
runs:
  using: node24   ← unsupported by GitHub Actions
  main: dist/index.js
```

GitHub validates action runtimes at scheduling time. An unsupported `runs.using` value causes the entire calling workflow to fail with `startup_failure` before any job starts.